### PR TITLE
Remove onClickListener from the GroupAdapter constructor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/example/src/main/java/com/genius/groupie/example/MainActivity.java
+++ b/example/src/main/java/com/genius/groupie/example/MainActivity.java
@@ -70,7 +70,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         gray = ContextCompat.getColor(this, R.color.background);
         betweenPadding = getResources().getDimensionPixelSize(R.dimen.padding_small);
 
-        groupAdapter = new GroupAdapter(this);
+        groupAdapter = new GroupAdapter();
         groupAdapter.setSpanCount(12);
         populateAdapter();
         layoutManager = new GridLayoutManager(this, groupAdapter.getSpanCount());
@@ -203,7 +203,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
 
     private CarouselItem makeCarouselItem() {
         CarouselItemDecoration carouselDecoration = new CarouselItemDecoration(gray, betweenPadding);
-        GroupAdapter carouselAdapter = new GroupAdapter(this);
+        GroupAdapter carouselAdapter = new GroupAdapter();
         for (int i = 0; i < 30; i++) {
             carouselAdapter.add(new CarouselCardItem(R.color.deep_purple_200));
         }

--- a/example/src/main/java/com/genius/groupie/example/item/CardItem.java
+++ b/example/src/main/java/com/genius/groupie/example/item/CardItem.java
@@ -3,13 +3,13 @@ package com.genius.groupie.example.item;
 import android.support.annotation.ColorRes;
 
 import com.genius.groupie.Item;
-import com.genius.groupie.example.MainActivity;
 import com.genius.groupie.example.databinding.ItemCardBinding;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.genius.groupie.example.MainActivity.*;
+import static com.genius.groupie.example.MainActivity.INSET;
+import static com.genius.groupie.example.MainActivity.INSET_TYPE_KEY;
 
 public class CardItem extends Item<ItemCardBinding> {
 

--- a/example/src/main/java/com/genius/groupie/example/item/CardItem.java
+++ b/example/src/main/java/com/genius/groupie/example/item/CardItem.java
@@ -3,13 +3,13 @@ package com.genius.groupie.example.item;
 import android.support.annotation.ColorRes;
 
 import com.genius.groupie.Item;
+import com.genius.groupie.example.MainActivity;
 import com.genius.groupie.example.databinding.ItemCardBinding;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.genius.groupie.example.MainActivity.INSET;
-import static com.genius.groupie.example.MainActivity.INSET_TYPE_KEY;
+import static com.genius.groupie.example.MainActivity.*;
 
 public class CardItem extends Item<ItemCardBinding> {
 

--- a/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
+++ b/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
@@ -5,7 +5,6 @@ import android.databinding.ViewDataBinding;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
@@ -15,13 +14,11 @@ import java.util.List;
  * An adapter that holds a list of Groups.
  */
 public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements Group.GroupDataObserver {
-    private final View.OnClickListener onItemClickListener;
+
     private final List<Group> groups = new ArrayList<>();
     private int spanCount = 1;
 
-    public GroupAdapter(View.OnClickListener onItemClickListener) {
-        this.onItemClickListener = onItemClickListener;
-    }
+    public GroupAdapter() { }
 
     private final GridLayoutManager.SpanSizeLookup spanSizeLookup = new GridLayoutManager.SpanSizeLookup() {
         @Override public int getSpanSize(int position) {
@@ -53,13 +50,12 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     @Override public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
-        Item contentItem = getItem(position);
-        contentItem.bind(holder, position, onItemClickListener);
     }
 
-    @Override public void onBindViewHolder(RecyclerView.ViewHolder holder, int position, List<Object> payloads) {
+    @Override
+    public void onBindViewHolder(RecyclerView.ViewHolder holder, int position, List<Object> payloads) {
         Item contentItem = getItem(position);
-        contentItem.bind(holder, position, payloads, onItemClickListener);
+        contentItem.bind(holder, position, payloads);
     }
 
     @Override public int getItemViewType(int position) {
@@ -78,7 +74,7 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
             }
         }
         throw new IndexOutOfBoundsException("Requested position " + position + "in group adapter " +
-                "but there are only " + count + " items");
+                                                    "but there are only " + count + " items");
     }
 
     public int getAdapterPosition(Item contentItem) {

--- a/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
+++ b/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
@@ -5,6 +5,7 @@ import android.databinding.ViewDataBinding;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
@@ -16,6 +17,7 @@ import java.util.List;
 public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements Group.GroupDataObserver {
 
     private final List<Group> groups = new ArrayList<>();
+    private View.OnClickListener onItemClickListener;
     private int spanCount = 1;
 
     public GroupAdapter() { }
@@ -43,6 +45,15 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         return spanCount;
     }
 
+    /**
+     * register a {@link android.view.View.OnClickListener} that listens to click at the root of
+     * each Item where {@link Item#isClickable()} returns true
+     */
+    public void setOnItemClickListener(View.OnClickListener onItemClickListener) {
+        this.onItemClickListener = onItemClickListener;
+    }
+
+
     @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int layoutResId) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
         ViewDataBinding binding = DataBindingUtil.inflate(inflater, layoutResId, parent, false);
@@ -55,7 +66,7 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     @Override
     public void onBindViewHolder(RecyclerView.ViewHolder holder, int position, List<Object> payloads) {
         Item contentItem = getItem(position);
-        contentItem.bind(holder, position, payloads);
+        contentItem.bind(holder, position, payloads, onItemClickListener);
     }
 
     @Override public int getItemViewType(int position) {

--- a/groupie/src/main/java/com/genius/groupie/Item.java
+++ b/groupie/src/main/java/com/genius/groupie/Item.java
@@ -3,6 +3,7 @@ package com.genius.groupie;
 import android.databinding.ViewDataBinding;
 import android.support.annotation.LayoutRes;
 import android.support.v7.widget.RecyclerView;
+import android.view.View;
 
 import java.util.List;
 import java.util.Map;
@@ -22,7 +23,7 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
 
     protected GroupDataObserver parentDataObserver;
 
-    public void bind(RecyclerView.ViewHolder viewHolder, int position, List<Object> payloads) {
+    public void bind(RecyclerView.ViewHolder viewHolder, int position, List<Object> payloads, View.OnClickListener onItemClickListener) {
         ViewHolder<T> holder = (ViewHolder<T>) viewHolder;
         if (getExtras() != null) {
             holder.getExtras().putAll(getExtras());
@@ -30,6 +31,8 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
         holder.setDragDirs(getDragDirs());
         holder.setSwipeDirs(getSwipeDirs());
         T binding = holder.binding;
+        boolean hasClickListener = isClickable() && onItemClickListener != null;
+        binding.getRoot().setOnClickListener(hasClickListener ? onItemClickListener : null);
         bind(binding, position, payloads);
         binding.executePendingBindings();
     }
@@ -78,6 +81,9 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
         return this == item ? 0 : -1;
     }
 
+    public boolean isClickable() {
+        return true;
+    }
 
     /**
      * A set of key/value pairs stored on the ViewHolder that can be useful for distinguishing

--- a/groupie/src/main/java/com/genius/groupie/Item.java
+++ b/groupie/src/main/java/com/genius/groupie/Item.java
@@ -3,17 +3,16 @@ package com.genius.groupie;
 import android.databinding.ViewDataBinding;
 import android.support.annotation.LayoutRes;
 import android.support.v7.widget.RecyclerView;
-import android.view.View;
 
 import java.util.List;
 import java.util.Map;
 
 /**
  * The base unit of content for a GroupAdapter.
- *
+ * <p>
  * Because an Item is a Group of size one, you don't need to use Groups directly if you don't want;
  * simply mix and match Items and add directly to the adapter.
- *
+ * <p>
  * If you want to use Groups, because Item extends Group, you can mix and match adding Items and
  * other Groups directly to the adapter.
  *
@@ -23,7 +22,7 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
 
     protected GroupDataObserver parentDataObserver;
 
-    public void bind(RecyclerView.ViewHolder viewHolder, int position, View.OnClickListener onItemClickListener) {
+    public void bind(RecyclerView.ViewHolder viewHolder, int position, List<Object> payloads) {
         ViewHolder<T> holder = (ViewHolder<T>) viewHolder;
         if (getExtras() != null) {
             holder.getExtras().putAll(getExtras());
@@ -31,20 +30,6 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
         holder.setDragDirs(getDragDirs());
         holder.setSwipeDirs(getSwipeDirs());
         T binding = holder.binding;
-        binding.getRoot().setOnClickListener(isClickable() ? onItemClickListener : null);
-        bind(binding, position);
-        binding.executePendingBindings();
-    }
-
-    public void bind(RecyclerView.ViewHolder viewHolder, int position, List<Object> payloads, View.OnClickListener onItemClickListener) {
-        ViewHolder<T> holder = (ViewHolder<T>) viewHolder;
-        if (getExtras() != null) {
-            holder.getExtras().putAll(getExtras());
-        }
-        holder.setDragDirs(getDragDirs());
-        holder.setSwipeDirs(getSwipeDirs());
-        T binding = holder.binding;
-        binding.getRoot().setOnClickListener(isClickable() ? onItemClickListener : null);
         bind(binding, position, payloads);
         binding.executePendingBindings();
     }
@@ -93,13 +78,11 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
         return this == item ? 0 : -1;
     }
 
-    public boolean isClickable() {
-        return true;
-    }
 
     /**
      * A set of key/value pairs stored on the ViewHolder that can be useful for distinguishing
      * items of the same view type.
+     *
      * @return
      */
     public Map<String, Object> getExtras() {


### PR DESCRIPTION
Hi, 

I have started playing with Groupie and so far I really like this lib.  
One thing that bothers me is that if I don't want my items to be clickable, I still need to provide an
onClickListener to the GroupAdapter and to override isClickable to false (so you also don't get 'click' sounds for unclickable elements).  

I think it would be easier to just drop this feature, it is easy to add click listener wherever you want in the item hierarchy with databinding anyway.