### PR TITLE
Make UpdatingGroup take in a callback: Closes #22

### DIFF
--- a/example/src/main/java/com/genius/groupie/example/MainActivity.java
+++ b/example/src/main/java/com/genius/groupie/example/MainActivity.java
@@ -59,7 +59,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     private ArrayList<UpdatableItem> updatableItems;
 
     // Hold a reference to the updating group, so we can, well, update it
-    private UpdatingGroup<UpdatableItem> updatingGroup;
+    private UpdatingGroup updatingGroup;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -131,7 +131,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
                 R.drawable.shuffle,
                 onShuffleClicked);
         updatingSection.setHeader(updatingHeader);
-        updatingGroup = new UpdatingGroup<>();
+        updatingGroup = new UpdatingGroup();
         updatableItems = new ArrayList<>();
         for (int i = 1; i <= 12; i++) {
             updatableItems.add(new UpdatableItem(R.color.blue_200, i));

--- a/example/src/main/java/com/genius/groupie/example/item/UpdatableItem.java
+++ b/example/src/main/java/com/genius/groupie/example/item/UpdatableItem.java
@@ -2,9 +2,7 @@ package com.genius.groupie.example.item;
 
 import android.support.annotation.ColorRes;
 
-import com.genius.groupie.UpdatingGroup;
-
-public class UpdatableItem extends SmallCardItem implements UpdatingGroup.Comparable<UpdatableItem> {
+public class UpdatableItem extends SmallCardItem {
 
     private final int index;
 
@@ -13,15 +11,8 @@ public class UpdatableItem extends SmallCardItem implements UpdatingGroup.Compar
         this.index = index;
     }
 
-    public int getIndex() {
+    @Override
+    public long getId() {
         return index;
-    }
-
-    @Override public boolean areContentsTheSame(UpdatableItem other) {
-        return true;
-    }
-
-    @Override public boolean areItemsTheSame(UpdatableItem other) {
-        return other.getIndex() == index;
     }
 }

--- a/groupie/src/main/java/com/genius/groupie/Item.java
+++ b/groupie/src/main/java/com/genius/groupie/Item.java
@@ -7,6 +7,7 @@ import android.view.View;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The base unit of content for a GroupAdapter.
@@ -21,7 +22,17 @@ import java.util.Map;
  */
 public abstract class Item<T extends ViewDataBinding> implements Group, SpanSizeProvider {
 
+    private static AtomicLong ID_COUNTER = new AtomicLong(0);
     protected GroupDataObserver parentDataObserver;
+    private final long id;
+
+    public Item() {
+        this(ID_COUNTER.decrementAndGet());
+    }
+
+    protected Item(long id) {
+        this.id = id;
+    }
 
     public void bind(RecyclerView.ViewHolder viewHolder, int position, View.OnClickListener onItemClickListener) {
         ViewHolder<T> holder = (ViewHolder<T>) viewHolder;
@@ -104,5 +115,18 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
      */
     public Map<String, Object> getExtras() {
         return null;
+    }
+
+    /**
+     * If you don't specify an id, this id is an auto-generated unique negative integer for each Item (the less
+     * likely to conflict with your model IDs.)
+     *
+     * You may prefer to override it with the ID of a model object, for example the primary key of
+     * an object from a database that it represents.  It is used to tell if items of the same view type
+     * are "the same as" each other in comparison using DiffUtil.
+     * @return
+     */
+    public long getId() {
+        return id;
     }
 }


### PR DESCRIPTION
Previously an UpdatingGroup had to be a homogeneous list of one type
of Item and that Item had to implement Comparable.

Now, UpdatingGroup can accept any type of Items and requires a Callback
explaining how to tell when they're the same, or contents are the same.