### PR TITLE
Change View.OnClickListener to OnItemClickListener

### DIFF
--- a/example/src/main/java/com/genius/groupie/example/MainActivity.java
+++ b/example/src/main/java/com/genius/groupie/example/MainActivity.java
@@ -9,11 +9,14 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
+import android.text.TextUtils;
 import android.view.View;
+import android.widget.Toast;
 
 import com.genius.groupie.ExpandableGroup;
 import com.genius.groupie.GroupAdapter;
 import com.genius.groupie.Item;
+import com.genius.groupie.OnItemClickListener;
 import com.genius.groupie.Section;
 import com.genius.groupie.TouchCallback;
 import com.genius.groupie.UpdatingGroup;
@@ -37,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-public class MainActivity extends AppCompatActivity implements View.OnClickListener {
+public class MainActivity extends AppCompatActivity {
 
     public static final String INSET_TYPE_KEY = "inset_type";
     public static final String FULL_BLEED = "full_bleed";
@@ -71,6 +74,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         betweenPadding = getResources().getDimensionPixelSize(R.dimen.padding_small);
 
         groupAdapter = new GroupAdapter();
+        groupAdapter.setOnItemClickListener(onItemClickListener);
         groupAdapter.setSpanCount(12);
         populateAdapter();
         layoutManager = new GridLayoutManager(this, groupAdapter.getSpanCount());
@@ -212,9 +216,17 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         return carouselItem;
     }
 
-    @Override public void onClick(View view) {
-
-    }
+    private OnItemClickListener onItemClickListener = new OnItemClickListener() {
+        @Override
+        public void onItemClick(Item item, View view) {
+            if (item instanceof CardItem) {
+                CardItem cardItem = (CardItem) item;
+                if (!TextUtils.isEmpty(cardItem.getText())) {
+                    Toast.makeText(MainActivity.this, cardItem.getText(), Toast.LENGTH_SHORT).show();
+                }
+            }
+        }
+    };
 
     @Override protected void onDestroy() {
         prefs.unregisterListener(onSharedPrefChangeListener);

--- a/example/src/main/java/com/genius/groupie/example/item/CardItem.java
+++ b/example/src/main/java/com/genius/groupie/example/item/CardItem.java
@@ -3,13 +3,13 @@ package com.genius.groupie.example.item;
 import android.support.annotation.ColorRes;
 
 import com.genius.groupie.Item;
-import com.genius.groupie.example.MainActivity;
 import com.genius.groupie.example.databinding.ItemCardBinding;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.genius.groupie.example.MainActivity.*;
+import static com.genius.groupie.example.MainActivity.INSET;
+import static com.genius.groupie.example.MainActivity.INSET_TYPE_KEY;
 
 public class CardItem extends Item<ItemCardBinding> {
 
@@ -42,5 +42,9 @@ public class CardItem extends Item<ItemCardBinding> {
         Map<String, Object> map = new HashMap<>();
         map.put(INSET_TYPE_KEY, INSET);
         return map;
+    }
+
+    public CharSequence getText() {
+        return text;
     }
 }

--- a/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
+++ b/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
@@ -5,7 +5,6 @@ import android.databinding.ViewDataBinding;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
@@ -17,7 +16,7 @@ import java.util.List;
 public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements Group.GroupDataObserver {
 
     private final List<Group> groups = new ArrayList<>();
-    private View.OnClickListener onItemClickListener;
+    private OnItemClickListener onItemClickListener;
     private int spanCount = 1;
     
     private final GridLayoutManager.SpanSizeLookup spanSizeLookup = new GridLayoutManager.SpanSizeLookup() {
@@ -44,13 +43,13 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     /**
-     * register a {@link android.view.View.OnClickListener} that listens to click at the root of
+     * Optionally register an {@link OnItemClickListener} that listens to click at the root of
      * each Item where {@link Item#isClickable()} returns true
+     * @param onItemClickListener
      */
-    public void setOnItemClickListener(View.OnClickListener onItemClickListener) {
+    public void setOnItemClickListener(OnItemClickListener onItemClickListener) {
         this.onItemClickListener = onItemClickListener;
     }
-
 
     @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int layoutResId) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
@@ -59,8 +58,7 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     }
 
     @Override public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
-        Item contentItem = getItem(position);
-        contentItem.bind(holder, position, onItemClickListener);
+        // Never called (all binds go through the version with payload)
     }
 
     @Override public void onBindViewHolder(RecyclerView.ViewHolder holder, int position, List<Object> payloads) {

--- a/groupie/src/main/java/com/genius/groupie/Item.java
+++ b/groupie/src/main/java/com/genius/groupie/Item.java
@@ -25,6 +25,14 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
     private static AtomicLong ID_COUNTER = new AtomicLong(0);
     protected GroupDataObserver parentDataObserver;
     private final long id;
+    private OnItemClickListener onItemClickListener;
+
+    private View.OnClickListener onClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+            onItemClickListener.onItemClick(Item.this, v);
+        }
+    };
 
     public Item() {
         this(ID_COUNTER.decrementAndGet());
@@ -34,29 +42,17 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
         this.id = id;
     }
 
-    public void bind(RecyclerView.ViewHolder viewHolder, int position, View.OnClickListener onItemClickListener) {
+    public void bind(RecyclerView.ViewHolder viewHolder, int position, List<Object> payloads, OnItemClickListener onItemClickListener) {
+        this.onItemClickListener = onItemClickListener;
         ViewHolder<T> holder = (ViewHolder<T>) viewHolder;
         if (getExtras() != null) {
             holder.getExtras().putAll(getExtras());
         }
         holder.setDragDirs(getDragDirs());
         holder.setSwipeDirs(getSwipeDirs());
+        viewHolder.itemView.setOnClickListener(isClickable() && onItemClickListener != null ? onClickListener : null);
         T binding = holder.binding;
-        binding.getRoot().setOnClickListener(isClickable() ? onItemClickListener : null);
-        bind(binding, position);
-        binding.executePendingBindings();
-    }
 
-    public void bind(RecyclerView.ViewHolder viewHolder, int position, List<Object> payloads, View.OnClickListener onItemClickListener) {
-        ViewHolder<T> holder = (ViewHolder<T>) viewHolder;
-        if (getExtras() != null) {
-            holder.getExtras().putAll(getExtras());
-        }
-        holder.setDragDirs(getDragDirs());
-        holder.setSwipeDirs(getSwipeDirs());
-        T binding = holder.binding;
-        boolean hasClickListener = isClickable() && onItemClickListener != null;
-        binding.getRoot().setOnClickListener(hasClickListener ? onItemClickListener : null);
         bind(binding, position, payloads);
         binding.executePendingBindings();
     }

--- a/groupie/src/main/java/com/genius/groupie/OnItemClickListener.java
+++ b/groupie/src/main/java/com/genius/groupie/OnItemClickListener.java
@@ -1,0 +1,9 @@
+package com.genius.groupie;
+
+import android.view.View;
+
+public interface OnItemClickListener {
+
+    void onItemClick(Item item, View view);
+
+}


### PR DESCRIPTION
This prevents the necessity of asking the adapter for the clicked
item. It's especially convenient if you have multiple nested adapters.

Also consolidate the onBind logic in GroupAdapter to clean up uncalled
code.