### PR TITLE
CircleCI: Copying unit test results for better reporting

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,3 +4,7 @@ machine:
 dependencies:
   pre:
     - echo y | android update sdk --no-ui --all --filter android-`grep -oP '(?<=compileSdkVersion )[0-9].*[0-9]' groupie/build.gradle`,extra-android-m2repository,build-tools-`grep -oP "(?<=buildToolsVersion .)[0-9].*[0-9]" groupie/build.gradle`
+test:
+  post:
+    - cp -r groupie/build/test-results/* $CIRCLE_TEST_REPORTS
+


### PR DESCRIPTION
Thanks for the library and sorry for the without notice PR.

CircleCI has nice reporting for unit test results so I just copied them after the tests finishes for CircleCI to report them.
The result, on succeeding build would be like this:

![image](https://cloud.githubusercontent.com/assets/1767669/19826302/ba0c4548-9dc1-11e6-945a-f4c453647c23.png)
