### PR TITLE
Fix Section addAll(position, groups) adapter notification

### DIFF
--- a/groupie/src/main/java/com/genius/groupie/Section.java
+++ b/groupie/src/main/java/com/genius/groupie/Section.java
@@ -58,9 +58,16 @@ public class Section extends NestedGroup {
 
     @Override
     public void addAll(int position, List<Group> groups) {
+        if (groups.isEmpty()) {
+            return;
+        }
+
         super.addAll(position, groups);
+
+        int notifyPosition = getItemCountWithoutFooter();
         this.children.addAll(position, groups);
-        notifyItemRangeInserted(getHeaderItemCount() + position, getItemCount(groups));
+        notifyItemRangeInserted(notifyPosition, getItemCount(groups));
+
         refreshEmptyState();
     }
 

--- a/groupie/src/main/java/com/genius/groupie/Section.java
+++ b/groupie/src/main/java/com/genius/groupie/Section.java
@@ -42,7 +42,8 @@ public class Section extends NestedGroup {
     public void add(int position, Group group) {
         super.add(position, group);
         children.add(position, group);
-        notifyItemRangeInserted(getHeaderItemCount() + position, group.getItemCount());
+        final int notifyPosition = getHeaderItemCount() + getItemCount(children.subList(0, position));
+        notifyItemRangeInserted(notifyPosition, group.getItemCount());
         refreshEmptyState();
     }
 
@@ -75,7 +76,7 @@ public class Section extends NestedGroup {
         super.add(group);
         int position = getItemCountWithoutFooter();
         children.add(group);
-        notifyItemInserted(getHeaderItemCount() + position);
+        notifyItemRangeInserted(getHeaderItemCount() + position, group.getItemCount());
         refreshEmptyState();
     }
 

--- a/groupie/src/main/java/com/genius/groupie/Section.java
+++ b/groupie/src/main/java/com/genius/groupie/Section.java
@@ -63,11 +63,10 @@ public class Section extends NestedGroup {
         }
 
         super.addAll(position, groups);
-
-        int notifyPosition = getItemCountWithoutFooter();
         this.children.addAll(position, groups);
-        notifyItemRangeInserted(notifyPosition, getItemCount(groups));
 
+        final int notifyPosition = getHeaderItemCount() + getItemCount(children.subList(0, position));
+        notifyItemRangeInserted(notifyPosition, getItemCount(groups));
         refreshEmptyState();
     }
 

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -398,4 +398,54 @@ public class SectionTest {
 
         assertNull(section.getGroup(0));
     }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void addAllAtNonZeroPositionWhenEmptyThrowIndexOutOfBoundsException() {
+        final Section section = new Section();
+        section.setGroupDataObserver(groupAdapter);
+        section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+    }
+
+    @Test
+    public void addAllAtPositionWhenEmptyNotifiesAdapterAtIndexZero() {
+        final Section section = new Section();
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(0, Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 0, 2);
+    }
+
+    @Test
+    public void addAllAtPositionWhenNonEmptyNotifiesAdapterAtCorrectIndex() {
+        final Section section = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(2, Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 2, 3);
+    }
+
+    @Test
+    public void addAllAtPositionWithEmptyNestedGroupNotifiesAdapterAtZeroIndex() {
+        final Section nestedSection = new Section();
+
+        final Section section = new Section();
+        section.add(nestedSection);
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 0, 3);
+    }
+
+    @Test
+    public void addAllAtPositionWithNestedGroupNotifiesAdapterAtCorrectIndex() {
+        final List<Group> nestedItems = Arrays.<Group>asList(new DummyItem(), new DummyItem());
+        final Section nestedSection = new Section(nestedItems);
+
+        final Section section = new Section();
+        section.add(nestedSection);
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 2, 2);
+    }
 }

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -437,7 +438,32 @@ public class SectionTest {
     }
 
     @Test
-    public void addAllAtPositionWithNestedGroupNotifiesAdapterAtCorrectIndex() {
+    public void addAllAtPositionFrontWithNestedGroupNotifiesAdapterAtCorrectIndex() {
+        final List<Group> nestedItems = Arrays.<Group>asList(new DummyItem(), new DummyItem());
+        final Section nestedSection = new Section(nestedItems);
+
+        final Section section = new Section();
+        section.add(nestedSection);
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(0, Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 0, 3);
+    }
+
+    @Test
+    public void addAllAtPositionMiddleWithNestedGroupNotifiesAdapterAtCorrectIndex() {
+        final Section nestedSection1 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        final Section nestedSection2 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+
+        final Section section = new Section(Arrays.<Group>asList(nestedSection1, nestedSection2));
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 2, 3);
+    }
+
+    @Test
+    public void addAllAtPositionEndWithNestedGroupNotifiesAdapterAtCorrectIndex() {
         final List<Group> nestedItems = Arrays.<Group>asList(new DummyItem(), new DummyItem());
         final Section nestedSection = new Section(nestedItems);
 

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -473,5 +474,42 @@ public class SectionTest {
 
         section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem()));
         verify(groupAdapter).onItemRangeInserted(section, 2, 2);
+    }
+
+    @Test
+    public void addGroupToNestedSectionNotifiesAtCorrectIndex() throws Exception {
+        final Section rootSection = new Section();
+
+        rootSection.setGroupDataObserver(groupAdapter);
+        groupAdapter.add(rootSection);
+
+        final Section nestedSection1 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        rootSection.add(nestedSection1);
+
+        final Section nestedSection2 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+
+        reset(groupAdapter);
+        rootSection.add(nestedSection2);
+        verify(groupAdapter).onItemRangeInserted(rootSection, 3, 2);
+    }
+
+    @Test
+    public void insertGroupToNestedSectionNotifiesAtCorrectIndex() throws Exception {
+        final Section rootSection = new Section();
+
+        rootSection.setGroupDataObserver(groupAdapter);
+        groupAdapter.add(rootSection);
+
+        final Section nestedSection1 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        rootSection.add(nestedSection1);
+
+        final Section nestedSection2 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        rootSection.add(nestedSection2);
+
+        final Section nestedSection3 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+
+        reset(groupAdapter);
+        rootSection.add(1, nestedSection3);
+        verify(groupAdapter).onItemRangeInserted(rootSection, 2, 2);
     }
 }


### PR DESCRIPTION
Section addAll() with position was not calculating the correct notifyItemRangeInserted position.