### PR TITLE
Notify parentDataObserver with correct position. Closes #46

### DIFF
--- a/groupie/src/main/java/com/genius/groupie/NestedGroup.java
+++ b/groupie/src/main/java/com/genius/groupie/NestedGroup.java
@@ -31,6 +31,16 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
         return size;
     }
 
+    protected int getGroupItemStartPosition(final Group group) {
+        final int groupIndex = getPosition(group);
+        int size = 0;
+        for (int i = 0; i < groupIndex; i++) {
+            final Group group1 = getGroup(i);
+            size += group1.getItemCount();
+        }
+        return size;
+    }
+
     public abstract Group getGroup(int position);
 
     public abstract int getGroupCount();
@@ -116,7 +126,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onChanged(Group group) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRangeChanged(this, getPosition(group), group.getItemCount());
+            parentDataObserver.onItemRangeChanged(this, getGroupItemStartPosition(group), group.getItemCount());
         }
     }
 
@@ -124,7 +134,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemInserted(Group group, int position) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemInserted(this, getPosition(group) + position);
+            parentDataObserver.onItemInserted(this, getGroupItemStartPosition(group) + position);
         }
     }
 
@@ -132,7 +142,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemChanged(Group group, int position) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemChanged(this, getPosition(group) + position);
+            parentDataObserver.onItemChanged(this, getGroupItemStartPosition(group) + position);
         }
     }
 
@@ -140,7 +150,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemChanged(Group group, int position, Object payload) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemChanged(this, getPosition(group) + position, payload);
+            parentDataObserver.onItemChanged(this, getGroupItemStartPosition(group) + position, payload);
         }
     }
 
@@ -148,7 +158,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemRemoved(Group group, int position) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRemoved(this, getPosition(group) + position);
+            parentDataObserver.onItemRemoved(this, getGroupItemStartPosition(group) + position);
         }
     }
 
@@ -156,7 +166,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemRangeChanged(Group group, int positionStart, int itemCount) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRangeChanged(this, getPosition(group) + positionStart, itemCount);
+            parentDataObserver.onItemRangeChanged(this, getGroupItemStartPosition(group) + positionStart, itemCount);
         }
     }
 
@@ -164,7 +174,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemRangeInserted(Group group, int positionStart, int itemCount) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRangeInserted(this, getPosition(group) + positionStart, itemCount);
+            parentDataObserver.onItemRangeInserted(this, getGroupItemStartPosition(group) + positionStart, itemCount);
         }
     }
 
@@ -172,7 +182,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemRangeRemoved(Group group, int positionStart, int itemCount) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRangeRemoved(this, getPosition(group) + positionStart, itemCount);
+            parentDataObserver.onItemRangeRemoved(this, getGroupItemStartPosition(group) + positionStart, itemCount);
         }
     }
 
@@ -180,7 +190,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemMoved(Group group, int fromPosition, int toPosition) {
         if (parentDataObserver != null) {
-            int groupPosition = getPosition(group);
+            int groupPosition = getGroupItemStartPosition(group);
             parentDataObserver.onItemMoved(this, groupPosition + fromPosition, groupPosition + toPosition);
         }
     }

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -14,6 +15,7 @@ import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -397,5 +399,23 @@ public class SectionTest {
         section.setHideWhenEmpty(true);
 
         assertNull(section.getGroup(0));
+    }
+
+    @Test
+    public void addItemToNestedSectionNotifiesAtCorrectIndex() throws Exception {
+        final Section rootSection = new Section();
+
+        rootSection.setGroupDataObserver(groupAdapter);
+        groupAdapter.add(rootSection);
+
+        final Section nestedSection1 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        rootSection.add(nestedSection1);
+
+        final Section nestedSection2 = new Section();
+        rootSection.add(nestedSection2);
+
+        reset(groupAdapter);
+        nestedSection2.add(new DummyItem());
+        verify(groupAdapter).onItemInserted(rootSection, 3);
     }
 }


### PR DESCRIPTION
Nested group was not correctly calculating item positions when notifying the parent data observer.