### PR TITLE
Section and NestedGroup change notification fixes. Closes #46 and #48

### DIFF
--- a/groupie/src/main/java/com/genius/groupie/NestedGroup.java
+++ b/groupie/src/main/java/com/genius/groupie/NestedGroup.java
@@ -35,8 +35,8 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
         final int groupIndex = getPosition(group);
         int size = 0;
         for (int i = 0; i < groupIndex; i++) {
-            final Group group1 = getGroup(i);
-            size += group1.getItemCount();
+            final Group currentGroup = getGroup(i);
+            size += currentGroup.getItemCount();
         }
         return size;
     }

--- a/groupie/src/main/java/com/genius/groupie/NestedGroup.java
+++ b/groupie/src/main/java/com/genius/groupie/NestedGroup.java
@@ -31,8 +31,12 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
         return size;
     }
 
-    protected int getGroupItemStartPosition(final Group group) {
+    protected int getItemCountBeforeGroup(final Group group) {
         final int groupIndex = getPosition(group);
+        return getItemCountBeforeGroup(groupIndex);
+    }
+
+    protected int getItemCountBeforeGroup(final int groupIndex) {
         int size = 0;
         for (int i = 0; i < groupIndex; i++) {
             final Group currentGroup = getGroup(i);
@@ -126,7 +130,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onChanged(Group group) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRangeChanged(this, getGroupItemStartPosition(group), group.getItemCount());
+            parentDataObserver.onItemRangeChanged(this, getItemCountBeforeGroup(group), group.getItemCount());
         }
     }
 
@@ -134,7 +138,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemInserted(Group group, int position) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemInserted(this, getGroupItemStartPosition(group) + position);
+            parentDataObserver.onItemInserted(this, getItemCountBeforeGroup(group) + position);
         }
     }
 
@@ -142,7 +146,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemChanged(Group group, int position) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemChanged(this, getGroupItemStartPosition(group) + position);
+            parentDataObserver.onItemChanged(this, getItemCountBeforeGroup(group) + position);
         }
     }
 
@@ -150,7 +154,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemChanged(Group group, int position, Object payload) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemChanged(this, getGroupItemStartPosition(group) + position, payload);
+            parentDataObserver.onItemChanged(this, getItemCountBeforeGroup(group) + position, payload);
         }
     }
 
@@ -158,7 +162,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemRemoved(Group group, int position) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRemoved(this, getGroupItemStartPosition(group) + position);
+            parentDataObserver.onItemRemoved(this, getItemCountBeforeGroup(group) + position);
         }
     }
 
@@ -166,7 +170,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemRangeChanged(Group group, int positionStart, int itemCount) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRangeChanged(this, getGroupItemStartPosition(group) + positionStart, itemCount);
+            parentDataObserver.onItemRangeChanged(this, getItemCountBeforeGroup(group) + positionStart, itemCount);
         }
     }
 
@@ -174,7 +178,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemRangeInserted(Group group, int positionStart, int itemCount) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRangeInserted(this, getGroupItemStartPosition(group) + positionStart, itemCount);
+            parentDataObserver.onItemRangeInserted(this, getItemCountBeforeGroup(group) + positionStart, itemCount);
         }
     }
 
@@ -182,7 +186,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemRangeRemoved(Group group, int positionStart, int itemCount) {
         if (parentDataObserver != null) {
-            parentDataObserver.onItemRangeRemoved(this, getGroupItemStartPosition(group) + positionStart, itemCount);
+            parentDataObserver.onItemRangeRemoved(this, getItemCountBeforeGroup(group) + positionStart, itemCount);
         }
     }
 
@@ -190,7 +194,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     @Override
     public void onItemMoved(Group group, int fromPosition, int toPosition) {
         if (parentDataObserver != null) {
-            int groupPosition = getGroupItemStartPosition(group);
+            int groupPosition = getItemCountBeforeGroup(group);
             parentDataObserver.onItemMoved(this, groupPosition + fromPosition, groupPosition + toPosition);
         }
     }

--- a/groupie/src/main/java/com/genius/groupie/Section.java
+++ b/groupie/src/main/java/com/genius/groupie/Section.java
@@ -58,9 +58,16 @@ public class Section extends NestedGroup {
 
     @Override
     public void addAll(int position, List<Group> groups) {
+        if (groups.isEmpty()) {
+            return;
+        }
+
         super.addAll(position, groups);
+
+        int notifyPosition = getItemCountWithoutFooter();
         this.children.addAll(position, groups);
-        notifyItemRangeInserted(getHeaderItemCount() + position, getItemCount(groups));
+        notifyItemRangeInserted(notifyPosition, getItemCount(groups));
+
         refreshEmptyState();
     }
 

--- a/groupie/src/main/java/com/genius/groupie/Section.java
+++ b/groupie/src/main/java/com/genius/groupie/Section.java
@@ -63,11 +63,10 @@ public class Section extends NestedGroup {
         }
 
         super.addAll(position, groups);
-
-        int notifyPosition = getItemCountWithoutFooter();
         this.children.addAll(position, groups);
-        notifyItemRangeInserted(notifyPosition, getItemCount(groups));
 
+        final int notifyPosition = getHeaderItemCount() + getItemCount(children.subList(0, position));
+        notifyItemRangeInserted(notifyPosition, getItemCount(groups));
         refreshEmptyState();
     }
 

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -398,4 +398,54 @@ public class SectionTest {
 
         assertNull(section.getGroup(0));
     }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void addAllAtNonZeroPositionWhenEmptyThrowIndexOutOfBoundsException() {
+        final Section section = new Section();
+        section.setGroupDataObserver(groupAdapter);
+        section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+    }
+
+    @Test
+    public void addAllAtPositionWhenEmptyNotifiesAdapterAtIndexZero() {
+        final Section section = new Section();
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(0, Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 0, 2);
+    }
+
+    @Test
+    public void addAllAtPositionWhenNonEmptyNotifiesAdapterAtCorrectIndex() {
+        final Section section = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(2, Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 2, 3);
+    }
+
+    @Test
+    public void addAllAtPositionWithEmptyNestedGroupNotifiesAdapterAtZeroIndex() {
+        final Section nestedSection = new Section();
+
+        final Section section = new Section();
+        section.add(nestedSection);
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 0, 3);
+    }
+
+    @Test
+    public void addAllAtPositionWithNestedGroupNotifiesAdapterAtCorrectIndex() {
+        final List<Group> nestedItems = Arrays.<Group>asList(new DummyItem(), new DummyItem());
+        final Section nestedSection = new Section(nestedItems);
+
+        final Section section = new Section();
+        section.add(nestedSection);
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 2, 2);
+    }
 }

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -437,7 +438,32 @@ public class SectionTest {
     }
 
     @Test
-    public void addAllAtPositionWithNestedGroupNotifiesAdapterAtCorrectIndex() {
+    public void addAllAtPositionFrontWithNestedGroupNotifiesAdapterAtCorrectIndex() {
+        final List<Group> nestedItems = Arrays.<Group>asList(new DummyItem(), new DummyItem());
+        final Section nestedSection = new Section(nestedItems);
+
+        final Section section = new Section();
+        section.add(nestedSection);
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(0, Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 0, 3);
+    }
+
+    @Test
+    public void addAllAtPositionMiddleWithNestedGroupNotifiesAdapterAtCorrectIndex() {
+        final Section nestedSection1 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+        final Section nestedSection2 = new Section(Arrays.<Group>asList(new DummyItem(), new DummyItem()));
+
+        final Section section = new Section(Arrays.<Group>asList(nestedSection1, nestedSection2));
+        section.setGroupDataObserver(groupAdapter);
+
+        section.addAll(1, Arrays.<Group>asList(new DummyItem(), new DummyItem(), new DummyItem()));
+        verify(groupAdapter).onItemRangeInserted(section, 2, 3);
+    }
+
+    @Test
+    public void addAllAtPositionEndWithNestedGroupNotifiesAdapterAtCorrectIndex() {
         final List<Group> nestedItems = Arrays.<Group>asList(new DummyItem(), new DummyItem());
         final Section nestedSection = new Section(nestedItems);
 

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -491,7 +491,7 @@ public class SectionTest {
 
         reset(groupAdapter);
         nestedSection2.add(new DummyItem());
-        verify(groupAdapter).onItemInserted(rootSection, 3);
+        verify(groupAdapter).onItemRangeInserted(rootSection, 3, 1);
     }
 
     public void addGroupToNestedSectionNotifiesAtCorrectIndex() throws Exception {

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -494,6 +494,7 @@ public class SectionTest {
         verify(groupAdapter).onItemRangeInserted(rootSection, 3, 1);
     }
 
+    @Test
     public void addGroupToNestedSectionNotifiesAtCorrectIndex() throws Exception {
         final Section rootSection = new Section();
 


### PR DESCRIPTION
Closes #46 and #48
- Section addAll(position, Group) was not calculating the correct notifyItemRangeInserted position.
- Section add(position, Group) was not calculating the correct notifyItemRangeInserted position.
- Section add(Group) change notification was not taking into account adding a group with items.
- Nested group was not correctly calculating item positions when notifying the parent data observer.
