### PR TITLE
Don’t overwrite item click listeners

### DIFF
--- a/groupie/src/main/java/com/genius/groupie/Item.java
+++ b/groupie/src/main/java/com/genius/groupie/Item.java
@@ -50,7 +50,9 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
         }
         holder.setDragDirs(getDragDirs());
         holder.setSwipeDirs(getSwipeDirs());
-        viewHolder.itemView.setOnClickListener(isClickable() && onItemClickListener != null ? onClickListener : null);
+        if (onItemClickListener != null) {
+            viewHolder.itemView.setOnClickListener(isClickable() ? onClickListener : null);
+        }
         T binding = holder.binding;
 
         bind(binding, position, payloads);


### PR DESCRIPTION
Don't set item click listener if the GroupAdapter click listener has not been set. Fixes #52.