### PR TITLE
Ensure UpdatingGroup registers itself as a change listener on its chi…

### DIFF
--- a/groupie/src/main/java/com/genius/groupie/NestedGroup.java
+++ b/groupie/src/main/java/com/genius/groupie/NestedGroup.java
@@ -121,6 +121,13 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
         group.setGroupDataObserver(null);
     }
 
+    @CallSuper
+    public void removeAll(List<? extends Group> groups) {
+        for (Group group : groups) {
+            group.setGroupDataObserver(null);
+        }
+    }
+
     /**
      * Every item in the group still exists but the data in each has changed (e.g. should rebind).
      *

--- a/groupie/src/main/java/com/genius/groupie/Section.java
+++ b/groupie/src/main/java/com/genius/groupie/Section.java
@@ -89,6 +89,20 @@ public class Section extends NestedGroup {
         refreshEmptyState();
     }
 
+    @Override
+    public void removeAll(List<? extends Group> groups) {
+        if (groups.isEmpty()) {
+            return;
+        }
+        super.removeAll(groups);
+        for (Group group : groups) {
+            int position = getPosition(group);
+            children.remove(group);
+            notifyItemRangeRemoved(position, group.getItemCount());
+        }
+        refreshEmptyState();
+    }
+
     /**
      * Optional. Set a placeholder for when the section's body is empty.
      * <p>

--- a/groupie/src/main/java/com/genius/groupie/UpdatingGroup.java
+++ b/groupie/src/main/java/com/genius/groupie/UpdatingGroup.java
@@ -41,7 +41,9 @@ public class UpdatingGroup extends NestedGroup {
 
     public void update(List<? extends Item> newItems) {
         DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(new UpdatingCallback(newItems));
+        super.removeAll(items);
         items.clear();
+        super.addAll(newItems);
         items.addAll(newItems);
         diffResult.dispatchUpdatesTo(listUpdateCallback);
     }

--- a/groupie/src/test/java/com/genius/groupie/ItemTest.java
+++ b/groupie/src/test/java/com/genius/groupie/ItemTest.java
@@ -3,8 +3,17 @@ package com.genius.groupie;
 import junit.framework.Assert;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
 public class ItemTest {
+
+    @Mock
+    GroupAdapter groupAdapter;
 
     @Test
     public void selfPositionIs0() throws Exception {
@@ -17,5 +26,14 @@ public class ItemTest {
         Item item = new DummyItem();
         Item differentItem = new DummyItem();
         Assert.assertEquals(-1, item.getPosition(differentItem));
+    }
+
+    @Test
+    public void notifyChangeNotifiesParentObserver() {
+        Item item = new DummyItem();
+        item.setGroupDataObserver(groupAdapter);
+        item.notifyChanged();
+
+        verify(groupAdapter).onItemChanged(item, 0);
     }
 }

--- a/groupie/src/test/java/com/genius/groupie/UpdatingGroupTest.java
+++ b/groupie/src/test/java/com/genius/groupie/UpdatingGroupTest.java
@@ -50,4 +50,19 @@ public class UpdatingGroupTest {
         verifyNoMoreInteractions(groupAdapter);
     }
 
+    @Test
+    public void changeAnItemNotifiesChange() {
+        List<Item> children = new ArrayList<Item>();
+        Item item = new DummyItem();
+        children.add(item);
+
+        UpdatingGroup group = new UpdatingGroup();
+        group.update(children);
+        group.setGroupDataObserver(groupAdapter);
+
+        item.notifyChanged();
+
+        verify(groupAdapter).onItemChanged(group, 0);
+    }
+
 }


### PR DESCRIPTION
…ldren

Before, it maintained its internal state by modifying a private list ofitems and never called NestedGroup.add() or remove(), which set the
parent group as a listener on the child.

It's an open question whether UpdatingGroup should extend NestedGroup in its current form at all, since it doesn't currently support add() or
remove() and also doesn't prevent their use.

For now, call the super methods add() and remove() within update()
to ensure child item events are appropriately propagated.