### PR TITLE
Add Item callbacks for unbind and isRecyclable

### DIFF
--- a/example/src/main/java/com/genius/groupie/example/item/CardItem.java
+++ b/example/src/main/java/com/genius/groupie/example/item/CardItem.java
@@ -5,9 +5,6 @@ import android.support.annotation.ColorInt;
 import com.genius.groupie.Item;
 import com.genius.groupie.example.databinding.ItemCardBinding;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import static com.genius.groupie.example.MainActivity.INSET;
 import static com.genius.groupie.example.MainActivity.INSET_TYPE_KEY;
 
@@ -23,6 +20,7 @@ public class CardItem extends Item<ItemCardBinding> {
     public CardItem(@ColorInt int colorRes, CharSequence text) {
         this.colorRes = colorRes;
         this.text = text;
+        getExtras().put(INSET_TYPE_KEY, INSET);
     }
 
     @Override public int getLayout() {
@@ -36,12 +34,6 @@ public class CardItem extends Item<ItemCardBinding> {
 
     public void setText(CharSequence text) {
         this.text = text;
-    }
-
-    @Override public Map<String, Object> getExtras() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(INSET_TYPE_KEY, INSET);
-        return map;
     }
 
     public CharSequence getText() {

--- a/example/src/main/java/com/genius/groupie/example/item/ColumnItem.java
+++ b/example/src/main/java/com/genius/groupie/example/item/ColumnItem.java
@@ -4,22 +4,14 @@ import android.support.annotation.ColorInt;
 
 import com.genius.groupie.example.MainActivity;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class ColumnItem extends CardItem {
 
     public ColumnItem(@ColorInt int colorRes, int index) {
         super(colorRes, String.valueOf(index));
+        getExtras().put(MainActivity.INSET_TYPE_KEY, MainActivity.INSET);
     }
 
     @Override public int getSpanSize(int spanCount, int position) {
         return spanCount / 2;
-    }
-
-    @Override public Map<String, Object> getExtras() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(MainActivity.INSET_TYPE_KEY, MainActivity.INSET);
-        return map;
     }
 }

--- a/example/src/main/java/com/genius/groupie/example/item/FullBleedCardItem.java
+++ b/example/src/main/java/com/genius/groupie/example/item/FullBleedCardItem.java
@@ -11,11 +11,6 @@ public class FullBleedCardItem extends CardItem {
 
     public FullBleedCardItem(@ColorRes int colorRes) {
         super(colorRes);
-    }
-
-    @Override public Map<String, Object> getExtras() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(MainActivity.INSET_TYPE_KEY, MainActivity.FULL_BLEED);
-        return map;
+        getExtras().put(MainActivity.INSET_TYPE_KEY, MainActivity.INSET);
     }
 }

--- a/example/src/main/java/com/genius/groupie/example/item/HeartCardItem.java
+++ b/example/src/main/java/com/genius/groupie/example/item/HeartCardItem.java
@@ -5,15 +5,11 @@ import android.support.annotation.ColorInt;
 import android.view.View;
 
 import com.genius.groupie.Item;
+import com.genius.groupie.example.MainActivity;
 import com.genius.groupie.example.R;
 import com.genius.groupie.example.databinding.ItemHeartCardBinding;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import static com.genius.groupie.example.MainActivity.INSET;
-import static com.genius.groupie.example.MainActivity.INSET_TYPE_KEY;
 
 public class HeartCardItem extends Item<ItemHeartCardBinding> {
 
@@ -28,6 +24,7 @@ public class HeartCardItem extends Item<ItemHeartCardBinding> {
         super(id);
         this.colorRes = colorRes;
         this.onFavoriteListener = onFavoriteListener;
+        getExtras().put(MainActivity.INSET_TYPE_KEY, MainActivity.INSET);
     }
 
     @Override
@@ -78,12 +75,6 @@ public class HeartCardItem extends Item<ItemHeartCardBinding> {
         } else {
             bind(binding, position);
         }
-    }
-
-    @Override public Map<String, Object> getExtras() {
-        Map<String, Object> map = new HashMap<>();
-        map.put(INSET_TYPE_KEY, INSET);
-        return map;
     }
 
     @Override

--- a/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
+++ b/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * An adapter that holds a list of Groups.
  */
-public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> implements GroupDataObserver {
+public class GroupAdapter extends RecyclerView.Adapter<ViewHolder> implements GroupDataObserver {
 
     private final List<Group> groups = new ArrayList<>();
     private OnItemClickListener onItemClickListener;
@@ -46,31 +46,47 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
     /**
      * Optionally register an {@link OnItemClickListener} that listens to click at the root of
      * each Item where {@link Item#isClickable()} returns true
-     * @param onItemClickListener
+     * @param onItemClickListener The click listener to set
      */
     public void setOnItemClickListener(OnItemClickListener onItemClickListener) {
         this.onItemClickListener = onItemClickListener;
     }
 
-    @Override public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int layoutResId) {
+    @Override public ViewHolder<? extends ViewDataBinding> onCreateViewHolder(ViewGroup parent, int layoutResId) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
         ViewDataBinding binding = DataBindingUtil.inflate(inflater, layoutResId, parent, false);
         return new ViewHolder<>(binding);
     }
 
-    @Override public void onBindViewHolder(RecyclerView.ViewHolder holder, int position) {
+    @Override public void onBindViewHolder(ViewHolder holder, int position) {
         // Never called (all binds go through the version with payload)
     }
 
-    @Override public void onBindViewHolder(RecyclerView.ViewHolder holder, int position, List<Object> payloads) {
+    @Override public void onBindViewHolder(ViewHolder holder, int position, List<Object> payloads) {
         Item contentItem = getItem(position);
         contentItem.bind(holder, position, payloads, onItemClickListener);
+    }
+
+    @Override
+    public void onViewRecycled(ViewHolder holder) {
+        Item contentItem = holder.getItem();
+        contentItem.unbind(holder);
+    }
+
+    @Override
+    public boolean onFailedToRecycleView(ViewHolder holder) {
+        Item contentItem = holder.getItem();
+        return contentItem.isRecyclable();
     }
 
     @Override public int getItemViewType(int position) {
         Item contentItem = getItem(position);
         if (contentItem == null) throw new RuntimeException("Invalid position " + position);
         return getItem(position).getLayout();
+    }
+
+    public Item getItem(ViewHolder holder) {
+        return holder.getItem();
     }
 
     public Item getItem(int position) {

--- a/groupie/src/main/java/com/genius/groupie/Item.java
+++ b/groupie/src/main/java/com/genius/groupie/Item.java
@@ -6,6 +6,7 @@ import android.support.annotation.LayoutRes;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -27,6 +28,7 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
     protected GroupDataObserver parentDataObserver;
     private final long id;
     private OnItemClickListener onItemClickListener;
+    private Map<String, Object> extras = new HashMap<>();
 
     private View.OnClickListener onClickListener = new View.OnClickListener() {
         @Override
@@ -160,7 +162,7 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
      * @return The map of extras
      */
     public Map<String, Object> getExtras() {
-        return null;
+        return extras;
     }
 
     /**

--- a/groupie/src/main/java/com/genius/groupie/Item.java
+++ b/groupie/src/main/java/com/genius/groupie/Item.java
@@ -1,6 +1,7 @@
 package com.genius.groupie;
 
 import android.databinding.ViewDataBinding;
+import android.support.annotation.CallSuper;
 import android.support.annotation.LayoutRes;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -11,14 +12,14 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The base unit of content for a GroupAdapter.
- *
+ * <p>
  * Because an Item is a Group of size one, you don't need to use Groups directly if you don't want;
  * simply mix and match Items and add directly to the adapter.
- *
+ * <p>
  * If you want to use Groups, because Item extends Group, you can mix and match adding Items and
  * other Groups directly to the adapter.
  *
- * @param <T>
+ * @param <T> The ViewDataBinding subclass associated with this Item.
  */
 public abstract class Item<T extends ViewDataBinding> implements Group, SpanSizeProvider {
 
@@ -42,16 +43,20 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
         this.id = id;
     }
 
-    public void bind(RecyclerView.ViewHolder viewHolder, int position, List<Object> payloads, OnItemClickListener onItemClickListener) {
+    /**
+     * Perform any actions required to set up the view for display.
+     *
+     * @param holder              The viewholder to bind
+     * @param position            The adapter position
+     * @param payloads            Any payloads (this list may be empty)
+     * @param onItemClickListener An optional adapter-level click listener
+     */
+    @CallSuper
+    public void bind(ViewHolder<T> holder, int position, List<Object> payloads, OnItemClickListener onItemClickListener) {
         this.onItemClickListener = onItemClickListener;
-        ViewHolder<T> holder = (ViewHolder<T>) viewHolder;
-        if (getExtras() != null) {
-            holder.getExtras().putAll(getExtras());
-        }
-        holder.setDragDirs(getDragDirs());
-        holder.setSwipeDirs(getSwipeDirs());
-        if (onItemClickListener != null) {
-            viewHolder.itemView.setOnClickListener(isClickable() ? onClickListener : null);
+        holder.bind(this);
+        if (onItemClickListener != null && isClickable()) {
+            holder.itemView.setOnClickListener(onClickListener);
         }
         T binding = holder.binding;
 
@@ -59,7 +64,32 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
         binding.executePendingBindings();
     }
 
-    @Override public int getSpanSize(int spanCount, int position) {
+    /**
+     * Do any cleanup required for the viewholder to be reused.
+     *
+     * @param holder The ViewHolder being recycled
+     */
+    @CallSuper
+    public void unbind(ViewHolder<T> holder) {
+        if (onItemClickListener != null && isClickable()) {
+            holder.itemView.setOnClickListener(null);
+        }
+        holder.unbind();
+    }
+
+    /**
+     * Whether the view should be recycled. Return false to prevent the view from being recycled.
+     * (Note that it may still be re-bound.)
+     *
+     * @see android.support.v7.widget.RecyclerView.Adapter#onFailedToRecycleView(RecyclerView.ViewHolder)
+     * @return Whether the view should be recycled.
+     */
+    public boolean isRecyclable() {
+        return true;
+    }
+
+    @Override
+    public int getSpanSize(int spanCount, int position) {
         return spanCount;
     }
 
@@ -79,27 +109,31 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
      * If you don't specify how to handle payloads in your implementation, they'll be ignored and
      * the adapter will do a full rebind.
      *
-     * @param viewBinding
-     * @param position
-     * @param payloads
+     * @param viewBinding The ViewDataBinding to bind
+     * @param position The adapter position
+     * @param payloads A list of payloads (may be empty)
      */
     public void bind(T viewBinding, int position, List<Object> payloads) {
         bind(viewBinding, position);
     }
 
-    @Override public int getItemCount() {
+    @Override
+    public int getItemCount() {
         return 1;
     }
 
-    @Override public Item getItem(int position) {
+    @Override
+    public Item getItem(int position) {
         return this;
     }
 
-    @Override public void setGroupDataObserver(GroupDataObserver groupDataObserver) {
+    @Override
+    public void setGroupDataObserver(GroupDataObserver groupDataObserver) {
         this.parentDataObserver = groupDataObserver;
     }
 
-    @Override public int getPosition(Item item) {
+    @Override
+    public int getPosition(Item item) {
         return this == item ? 0 : -1;
     }
 
@@ -122,7 +156,8 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
     /**
      * A set of key/value pairs stored on the ViewHolder that can be useful for distinguishing
      * items of the same view type.
-     * @return
+     *
+     * @return The map of extras
      */
     public Map<String, Object> getExtras() {
         return null;
@@ -131,11 +166,12 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
     /**
      * If you don't specify an id, this id is an auto-generated unique negative integer for each Item (the less
      * likely to conflict with your model IDs.)
-     *
+     * <p>
      * You may prefer to override it with the ID of a model object, for example the primary key of
      * an object from a database that it represents.  It is used to tell if items of the same view type
      * are "the same as" each other in comparison using DiffUtil.
-     * @return
+     *
+     * @return A unique id
      */
     public long getId() {
         return id;

--- a/groupie/src/main/java/com/genius/groupie/ViewHolder.java
+++ b/groupie/src/main/java/com/genius/groupie/ViewHolder.java
@@ -3,37 +3,38 @@ package com.genius.groupie;
 import android.databinding.ViewDataBinding;
 import android.support.v7.widget.RecyclerView;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class ViewHolder<T extends ViewDataBinding> extends RecyclerView.ViewHolder {
     public final T binding;
-    private final Map<String, Object> extras = new HashMap<>();
-    private int swipeDirs = 0;
-    private int dragDirs = 0;
+    private Item item;
 
     public ViewHolder(T binding) {
         super(binding.getRoot());
         this.binding = binding;
     }
 
+    public void bind(Item item) {
+        this.item = item;
+    }
+
+    public void unbind() {
+        this.item = null;
+    }
+
     public Map<String, Object> getExtras() {
-        return extras;
+        return item.getExtras();
     }
 
     public int getSwipeDirs() {
-        return swipeDirs;
-    }
-
-    public void setSwipeDirs(int swipeDirs) {
-        this.swipeDirs = swipeDirs;
+        return item.getSwipeDirs();
     }
 
     public int getDragDirs() {
-        return dragDirs;
+        return item.getDragDirs();
     }
 
-    public void setDragDirs(int dragDirs) {
-        this.dragDirs = dragDirs;
+    public Item getItem() {
+        return item;
     }
 }


### PR DESCRIPTION
In order to accomplish a callback for unbinding the viewholder, the
viewholder must hold a reference to the Item. I was nervous about
coupling them earlier, but I think it's the only way that makes sense.

I also changed GroupAdapter to specify com.genius.groupie.ViewHolder,
which removes the need for some casting, and improved the javadoc a little.