### PR TITLE
Accept Collections of Groups

### DIFF
--- a/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
+++ b/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
@@ -9,6 +9,7 @@ import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -147,7 +148,7 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
      * All groups in the list must be non-null.
      * @param groups
      */
-    public void addAll(@NonNull List<? extends Group> groups) {
+    public void addAll(@NonNull Collection<? extends Group> groups) {
         if (groups.contains(null)) throw new RuntimeException("List of groups can't contain null!");
         int itemCountBeforeGroup = getItemCount();
         int additionalSize = 0;
@@ -168,7 +169,7 @@ public class GroupAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> 
         notifyItemRangeRemoved(position, count);
     }
 
-    public void putGroup(@NonNull int index, Group group) {
+    public void add(@NonNull int index, Group group) {
         if (group == null) throw new RuntimeException("Group cannot be null");
         group.setGroupDataObserver(this);
         groups.add(index, group);

--- a/groupie/src/main/java/com/genius/groupie/NestedGroup.java
+++ b/groupie/src/main/java/com/genius/groupie/NestedGroup.java
@@ -2,6 +2,7 @@ package com.genius.groupie;
 
 import android.support.annotation.CallSuper;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -23,7 +24,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
         return size;
     }
 
-    protected final int getItemCount(List<? extends Group> groups) {
+    protected final int getItemCount(Collection<? extends Group> groups) {
         int size = 0;
         for (Group group : groups) {
             size += group.getItemCount();
@@ -98,7 +99,7 @@ public abstract class NestedGroup implements Group, GroupDataObserver {
     }
 
     @CallSuper
-    public void addAll(List<? extends Group> groups) {
+    public void addAll(Collection<? extends Group> groups) {
         for (Group group : groups) {
             group.setGroupDataObserver(this);
         }

--- a/groupie/src/main/java/com/genius/groupie/Section.java
+++ b/groupie/src/main/java/com/genius/groupie/Section.java
@@ -4,6 +4,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -33,7 +34,7 @@ public class Section extends NestedGroup {
         this(null, children);
     }
 
-    public Section(@Nullable Group header, List<? extends Group> children) {
+    public Section(@Nullable Group header, Collection<? extends Group> children) {
         this.header = header;
         addAll(children);
     }
@@ -48,7 +49,7 @@ public class Section extends NestedGroup {
     }
 
     @Override
-    public void addAll(List<? extends Group> groups) {
+    public void addAll(Collection<? extends Group> groups) {
         if (groups.isEmpty()) return;
         super.addAll(groups);
         int position = getItemCountWithoutFooter();

--- a/groupie/src/test/java/com/genius/groupie/GroupAdapterTest.java
+++ b/groupie/src/test/java/com/genius/groupie/GroupAdapterTest.java
@@ -1,12 +1,16 @@
 package com.genius.groupie;
 
+import junit.framework.Assert;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GroupAdapterTest {
@@ -37,7 +41,16 @@ public class GroupAdapterTest {
 
     @Test(expected=RuntimeException.class)
     public void putGroupMustBeNonNull() {
-        groupAdapter.putGroup(0, null);
+        groupAdapter.add(0, null);
+    }
+
+    public void addAllWorksWithSets() {
+        Set<Item> groupSet = new HashSet<>();
+        groupSet.add(new DummyItem());
+        groupSet.add(new DummyItem());
+
+        groupAdapter.addAll(groupSet);
+        Assert.assertEquals(2, groupAdapter.getItemCount());
     }
 
 }

--- a/groupie/src/test/java/com/genius/groupie/SectionTest.java
+++ b/groupie/src/test/java/com/genius/groupie/SectionTest.java
@@ -1,5 +1,7 @@
 package com.genius.groupie;
 
+import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -8,7 +10,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -564,5 +568,16 @@ public class SectionTest {
         reset(groupAdapter);
         rootSection.add(1, nestedSection3);
         verify(groupAdapter).onItemRangeInserted(rootSection, 2, 2);
+    }
+
+    public void addAllWorksWithSets() {
+        final Section testSection = new Section();
+
+        Set<Item> itemSet = new HashSet<>();
+        itemSet.add(new DummyItem());
+        itemSet.add(new DummyItem());
+
+        testSection.addAll(itemSet);
+        Assert.assertEquals(2, testSection.getItemCount());
     }
 }


### PR DESCRIPTION
Also renames GroupAdapter.putGroup(Group) to add(Group) to be more consistent
with method naming